### PR TITLE
fix for having two albums with the same name by two different artists

### DIFF
--- a/play_pi/management/commands/init_gplay.py
+++ b/play_pi/management/commands/init_gplay.py
@@ -48,29 +48,34 @@ class Command(BaseCommand):
             if a not in artists:
                 artist = Artist()
                 artist.name = a
+                
                 try:
                     artist.art_url = song['artistImageBaseUrl']
                 except:
                     artist.art_url = ""
+                
                 artist.save()
                 artists.append(a)
-                self.stdout.write('Added artist: '+ a)
+                self.stdout.write('Added artist: ' + a)
             else:
                 artist = Artist.objects.get(name=a)
             track.artist = artist
 
-            if song['album'] not in albums:
+            if song['album'] + a not in albums:
                 album = Album()
                 album.name = song['album']
                 album.artist = artist
+                album.year = song['year']
+               
                 try:
                     album.art_url = song['albumArtUrl']
                 except:
                     album.art_url = ""
+                    
                 album.save()
-                albums.append(song['album'])
+                albums.append(song['album'] + a)
             else:
-                album = Album.objects.get(name=song['album'])
+                album = Album.objects.get(name=song['album'], artist=artist)
             track.album = album
 
             track.name = song['title']

--- a/play_pi/models.py
+++ b/play_pi/models.py
@@ -7,10 +7,14 @@ class Artist(models.Model):
 
 
 class Album(models.Model):
-	name = models.CharField(max_length=200, unique=True)
-	art_url = models.CharField(max_length=200)
+	name = models.CharField(max_length=200)
 	artist = models.ForeignKey(Artist)
-
+	year = models.IntegerField(default=0)
+	art_url = models.CharField(max_length=200)
+	
+	class Meta:
+		unique_together = ("name", "artist")
+	
 
 class Track(models.Model):
 	name = models.CharField(max_length=200)


### PR DESCRIPTION
When using play-pi I faced a problem when having two albums with the same name but from different artists. play-pi will only add one of these albums to the database and will ignore the other one because it doesn't cover the case when two artists come up with the same name for their album (imagine two different artists naming their album 'love').

This commit should fix this issue.

You might also ask what happens if two different bands have the same band name. Well, in this case they are seen as the same band - imho that's the ususal behavior of a music player. Since there is no location tag, you have to rename them differently like 'Band [USA] and 'Band [EU]'  for example.
