### PR TITLE
Master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Django==1.5
 appdirs==1.4.0
 argparse==1.2.1
 decorator==3.4.0
-#distribute==0.6.24
 gmusicapi==7.0.0
 httplib2==0.9
 mock==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.5
 appdirs==1.4.0
 argparse==1.2.1
 decorator==3.4.0
-distribute==0.6.24
+#distribute==0.6.24
 gmusicapi==7.0.0
 httplib2==0.9
 mock==1.0.1


### PR DESCRIPTION
Distribute is a deprecated fork of the Setuptools project.

Since the Setuptools 0.7 release, Setuptools and Distribute have merged
and Distribute is no longer being maintained.

http://pythonhosted.org/distribute/
